### PR TITLE
Permits to build a DFA which returns the "applied distance".

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -283,6 +283,19 @@ fn test_prefix() {
     }
 }
 
+#[test]
+fn test_applied_distance() {
+    let q: &str = "abcde";
+    let nfa = LevenshteinNFA::levenshtein(1, true);
+    let parametric_dfa = ParametricDFA::from_nfa(&nfa);
+    let dfa = parametric_dfa.build_custom_dfa(q, true, true);
+    assert_eq!(dfa.eval(&"abcde"), Distance::Exact(0u8));
+    assert_eq!(dfa.eval(&"abcd"), Distance::Exact(0u8));
+    assert_eq!(dfa.eval(&"abde"), Distance::Exact(1u8));
+    assert_eq!(dfa.eval(&"abdce"), Distance::Exact(1u8));
+    assert_eq!(dfa.eval(&"abbbb"), Distance::AtLeast(2u8));
+}
+
 fn test_prefix_aux(
     param_dfa: &ParametricDFA,
     query: &str,


### PR DESCRIPTION
In contrast to reporting the "total" distance needed to match the
given query. This DFA will only report the number of edits which
have been performed so far.

This can be used to "inverse" prefix searches (check if the terms
scanned by the DFA are a prefix of the query).