### PR TITLE
Reveal the actual offset (number of characater consumed) for a partial match.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ impl LevenshteinAutomatonBuilder {
         }
     }
 
-    /// Builds a Finite Determinstic Automaton to compute
+    /// Builds a Finite Deterministic Automaton to compute
     /// the levenshtein distance to a fixed given `query`.
     ///
     /// There is no guarantee that the resulting DFA is minimal
@@ -94,7 +94,7 @@ impl LevenshteinAutomatonBuilder {
         self.parametric_dfa.build_dfa(query, false)
     }
 
-    /// Builds a Finite Determinstic Automaton that computes
+    /// Builds a Finite Deterministic Automaton that computes
     /// the prefix levenshtein distance to a given `query`.
     ///
     /// Given a test string, the resulting distance is defined as
@@ -108,5 +108,14 @@ impl LevenshteinAutomatonBuilder {
     /// See also [.build_dfa(...)](./struct.LevenshteinAutomatonBuilder.html#method.build_dfa).
     pub fn build_prefix_dfa(&self, query: &str) -> DFA {
         self.parametric_dfa.build_dfa(query, true)
+    }
+
+    /// Builds a Finite Deterministic Automaton that computes the actually applied edit distance
+    /// for a given query.
+    ///
+    /// This can be used to compute partial matches. In this case [DFA::offset] can be used to
+    /// determine the number of accepted / consumed characters.
+    pub fn build_applied_distance_dfa(&self, query: &str) -> DFA {
+        self.parametric_dfa.build_custom_dfa(query, false, true)
     }
 }

--- a/src/parametric_dfa.rs
+++ b/src/parametric_dfa.rs
@@ -163,13 +163,13 @@ impl ParametricDFA {
             };
 
             if prefix && self.is_prefix_sink(state, query_len) {
-                dfa_builder.add_state(state_id, distance, state_id);
+                dfa_builder.add_state(state_id, distance, state.offset, state_id);
             } else {
                 let default_successor = self.transition(state, 0u32).apply(state);
                 let default_successor_id =
                     parametric_state_index.get_or_allocate(default_successor);
                 let mut state_builder =
-                    dfa_builder.add_state(state_id, distance, default_successor_id);
+                    dfa_builder.add_state(state_id, distance, state.offset, default_successor_id);
                 for &(ref chr, ref characteristic_vec) in alphabet.iter() {
                     let chi = characteristic_vec.shift_and_mask(state.offset as usize, mask);
                     let dest_state: ParametricState = self.transition(state, chi).apply(state);


### PR DESCRIPTION
Using the applied edit distance, a DFA can be constructed which is then used to split the "query" into its sub words, using a dictionary. However, as we cannot rely on the number of steps performed within the automaton (due to skips / inserts), we have to actually reveal the number of characters consumed when a certain state is reached.